### PR TITLE
feat: Use yt_loader in flekspy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "flekspy==0.2.3",
+    "flekspy>=0.6.0",
     "pyvlasiator>=0.1.4",
     "scikit-learn>=1.5.2",
     "scipy>=1.14.1",

--- a/src/vdfpy/fleks/fleks.py
+++ b/src/vdfpy/fleks/fleks.py
@@ -16,7 +16,7 @@ def load(filename: str, left_edge=None, right_edge=None) -> pd.DataFrame:
     Returns:
         A pandas DataFrame with 2D particle raw data and moments.
     """
-    ds = fl.load(filename)
+    ds = fl.load(filename, use_yt_loader=True)
     if left_edge is None:
         left_edge = ds.domain_left_edge
     if right_edge is None: 


### PR DESCRIPTION
Updated the `flekspy.load` call to include the `use_yt_loader=True` option. This allows for the use of the legacy `yt` data loader, which simplifies the data access logic and restores the original behavior of the `load` function.