### PR TITLE
feat: Switch to pydata-sphinx-theme and consolidate dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,4 +36,4 @@ nb_execution_timeout = 60
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "pydata_sphinx_theme"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-flekspy
-myst-nb
-myst-parser
-pyvlasiator
-pyspedas
-seaborn
-sphinx-autoapi
-sphinx-rtd-theme
-umap-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,24 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+docs = [
+    "flekspy",
+    "myst-nb",
+    "myst-parser",
+    "pydata-sphinx-theme",
+    "pyvlasiator",
+    "pyspedas",
+    "seaborn",
+    "sphinx-autoapi",
+    "umap-learn",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-benchmark>=4.0.0",
     "pytest-cov>=4.1.0",
     "jupyter>=1.0.0",
     "matplotlib>=3.7.2",
-    "myst-nb>=1.0.0",
-    "seaborn>=0.13.2",
-    "sphinx-autoapi>=3.0.0",
-    "sphinx-rtd-theme>=2.0.0",
+    "vdfpy[docs]",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,11 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "flekspy",
-    "myst-nb",
-    "myst-parser",
-    "pydata-sphinx-theme",
-    "pyvlasiator",
-    "pyspedas",
-    "seaborn",
-    "sphinx-autoapi",
-    "umap-learn",
+    "myst-nb>=1.0.0",
+    "myst-parser>=2.0.0",
+    "pydata-sphinx-theme>=0.15.0",
+    "seaborn>=0.13.2",
+    "sphinx-autoapi>=3.0.0",
 ]
 dev = [
     "pytest>=8.0.0",


### PR DESCRIPTION
Switched the Sphinx theme to `pydata-sphinx-theme` for a more modern look and feel.

Consolidated the documentation dependencies from `docs/requirements.txt` into `pyproject.toml` under a new `[project.optional-dependencies.docs]` section. The `dev` dependencies were also updated to install the documentation dependencies.