### PR TITLE
feat: Add Box-Muller and MCMC sampling methods

### DIFF
--- a/src/vdfpy/generator/__init__.py
+++ b/src/vdfpy/generator/__init__.py
@@ -1,1 +1,1 @@
-from .generator import make_clusters
+from .generator import make_clusters, sample_box_muller, sample_mcmc

--- a/src/vdfpy/generator/generator.py
+++ b/src/vdfpy/generator/generator.py
@@ -134,3 +134,70 @@ def make_clusters(
     df = pd.concat([dclass, d1, d2, d3, d4], axis=1)
 
     return df
+
+
+def sample_box_muller(
+    n_particles: int, bulk_velocity: float, temperature: float
+) -> np.ndarray:
+    """Sample particles from a Maxwellian distribution using the Box-Muller method.
+    Args:
+        n_particles (int): Number of particles to sample.
+        bulk_velocity (float): Bulk velocity of the distribution.
+        temperature (float): Temperature of the distribution.
+    Returns:
+        np.ndarray: Array of particle velocities.
+    """
+    # Generate uniform random numbers
+    u1 = np.random.rand(n_particles // 2)
+    u2 = np.random.rand(n_particles // 2)
+    # Box-Muller transform
+    r = np.sqrt(-2 * np.log(u1))
+    theta = 2 * np.pi * u2
+    x = r * np.cos(theta)
+    y = r * np.sin(theta)
+    # Combine the two sets of random numbers
+    z = np.concatenate((x, y))
+    # If n_particles is odd, generate one more random number
+    if n_particles % 2 != 0:
+        u1 = np.random.rand(1)
+        u2 = np.random.rand(1)
+        r = np.sqrt(-2 * np.log(u1))
+        theta = 2 * np.pi * u2
+        z = np.append(z, r * np.cos(theta))
+
+    # Scale and shift to match the given moments
+    sigma = np.sqrt(temperature)
+    velocities = bulk_velocity + sigma * z
+    return velocities
+
+
+def sample_mcmc(
+    n_particles: int,
+    log_prob_func: callable,
+    initial_state: np.ndarray,
+    proposal_width: float = 1.0,
+) -> np.ndarray:
+    """Sample particles from a custom distribution using the MCMC method.
+    Args:
+        n_particles (int): Number of particles to sample.
+        log_prob_func (callable): Function that computes the log probability of the distribution.
+        initial_state (np.ndarray): Initial state for the MCMC sampler.
+        proposal_width (float, optional): Width of the proposal distribution. Defaults to 1.0.
+    Returns:
+        np.ndarray: Array of particle velocities.
+    """
+    # Initialize the MCMC chain
+    chain = np.zeros(n_particles)
+    chain[0] = initial_state
+    # Run the MCMC sampler
+    for i in range(1, n_particles):
+        # Propose a new state
+        proposal = chain[i - 1] + np.random.normal(0, proposal_width)
+        # Compute the acceptance ratio
+        log_acceptance_ratio = log_prob_func(proposal) - log_prob_func(chain[i - 1])
+        # Accept or reject the proposal
+        if np.log(np.random.rand()) < log_acceptance_ratio:
+            chain[i] = proposal
+        else:
+            chain[i] = chain[i - 1]
+    return chain

--- a/src/vdfpy/generator/generator.py
+++ b/src/vdfpy/generator/generator.py
@@ -137,33 +137,34 @@ def make_clusters(
 
 
 def sample_box_muller(
-    n_particles: int, bulk_velocity: float, temperature: float
+    n_particles: int, bulk_velocity: float, temperature: float, *, rng: np.random.Generator = None
 ) -> np.ndarray:
     """Sample particles from a Maxwellian distribution using the Box-Muller method.
     Args:
         n_particles (int): Number of particles to sample.
         bulk_velocity (float): Bulk velocity of the distribution.
         temperature (float): Temperature of the distribution.
+        rng (np.random.Generator, optional): Random number generator instance. Defaults to None.
     Returns:
         np.ndarray: Array of particle velocities.
     """
-    # Generate uniform random numbers
-    u1 = np.random.rand(n_particles // 2)
-    u2 = np.random.rand(n_particles // 2)
-    # Box-Muller transform
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # We need n_particles samples, Box-Muller generates pairs of samples.
+    # So we generate ceil(n_particles / 2) pairs.
+    num_pairs = (n_particles + 1) // 2
+    u1 = rng.random(num_pairs)
+    u2 = rng.random(num_pairs)
+
+    # Box-Muller transform for standard normal
     r = np.sqrt(-2 * np.log(u1))
     theta = 2 * np.pi * u2
     x = r * np.cos(theta)
     y = r * np.sin(theta)
-    # Combine the two sets of random numbers
-    z = np.concatenate((x, y))
-    # If n_particles is odd, generate one more random number
-    if n_particles % 2 != 0:
-        u1 = np.random.rand(1)
-        u2 = np.random.rand(1)
-        r = np.sqrt(-2 * np.log(u1))
-        theta = 2 * np.pi * u2
-        z = np.append(z, r * np.cos(theta))
+
+    # Combine and truncate to get n_particles samples
+    z = np.concatenate((x, y))[:n_particles]
 
     # Scale and shift to match the given moments
     sigma = np.sqrt(temperature)
@@ -174,30 +175,40 @@ def sample_box_muller(
 def sample_mcmc(
     n_particles: int,
     log_prob_func: callable,
-    initial_state: np.ndarray,
+    initial_state: float,
+    rng: np.random.Generator,
     proposal_width: float = 1.0,
+    burn_in: int = 100,
 ) -> np.ndarray:
     """Sample particles from a custom distribution using the MCMC method.
     Args:
         n_particles (int): Number of particles to sample.
         log_prob_func (callable): Function that computes the log probability of the distribution.
-        initial_state (np.ndarray): Initial state for the MCMC sampler.
+        initial_state (float): Initial state for the MCMC sampler.
+        rng (np.random.Generator): Random number generator.
         proposal_width (float, optional): Width of the proposal distribution. Defaults to 1.0.
+        burn_in (int, optional): Number of burn-in samples to discard. Defaults to 100.
     Returns:
         np.ndarray: Array of particle velocities.
     """
     # Initialize the MCMC chain
-    chain = np.zeros(n_particles)
+    total_samples = n_particles + burn_in
+    chain = np.zeros(total_samples)
     chain[0] = initial_state
+    log_prob_current = log_prob_func(initial_state)
+
     # Run the MCMC sampler
-    for i in range(1, n_particles):
+    for i in range(1, total_samples):
         # Propose a new state
-        proposal = chain[i - 1] + np.random.normal(0, proposal_width)
+        proposal = chain[i - 1] + rng.normal(0, proposal_width)
         # Compute the acceptance ratio
-        log_acceptance_ratio = log_prob_func(proposal) - log_prob_func(chain[i - 1])
+        log_prob_proposal = log_prob_func(proposal)
+        log_acceptance_ratio = log_prob_proposal - log_prob_current
         # Accept or reject the proposal
-        if np.log(np.random.rand()) < log_acceptance_ratio:
+        if np.log(rng.random()) < log_acceptance_ratio:
             chain[i] = proposal
+            log_prob_current = log_prob_proposal
         else:
             chain[i] = chain[i - 1]
-    return chain
+
+    return chain[burn_in:]

--- a/tests/generator/test_generator.py
+++ b/tests/generator/test_generator.py
@@ -1,0 +1,29 @@
+import numpy as np
+from vdfpy.generator import sample_box_muller, sample_mcmc
+
+
+def test_sample_box_muller():
+    """Test the Box-Muller sampler."""
+    np.random.seed(0)
+    n_particles = 1000
+    bulk_velocity = 1.0
+    temperature = 2.0
+    velocities = sample_box_muller(n_particles, bulk_velocity, temperature)
+    # Check the moments of the sampled distribution
+    assert np.isclose(np.mean(velocities), bulk_velocity, atol=0.1)
+    assert np.isclose(np.var(velocities), temperature, atol=0.1)
+
+
+def test_sample_mcmc():
+    """Test the MCMC sampler."""
+    np.random.seed(0)
+    # Define a custom log probability function (e.g., a standard normal distribution)
+    def log_prob_func(x):
+        return -0.5 * x**2
+
+    n_particles = 1000
+    initial_state = 0.0
+    samples = sample_mcmc(n_particles, log_prob_func, initial_state)
+    # Check the moments of the sampled distribution
+    assert np.isclose(np.mean(samples), 0, atol=0.1)
+    assert np.isclose(np.var(samples), 1, atol=0.1)

--- a/tests/generator/test_generator.py
+++ b/tests/generator/test_generator.py
@@ -4,11 +4,13 @@ from vdfpy.generator import sample_box_muller, sample_mcmc
 
 def test_sample_box_muller():
     """Test the Box-Muller sampler."""
-    np.random.seed(0)
-    n_particles = 1000
+    rng = np.random.default_rng(0)
+    n_particles = 10000
     bulk_velocity = 1.0
     temperature = 2.0
-    velocities = sample_box_muller(n_particles, bulk_velocity, temperature)
+    velocities = sample_box_muller(
+        n_particles, bulk_velocity, temperature, rng=rng
+    )
     # Check the moments of the sampled distribution
     assert np.isclose(np.mean(velocities), bulk_velocity, atol=0.1)
     assert np.isclose(np.var(velocities), temperature, atol=0.1)
@@ -16,14 +18,16 @@ def test_sample_box_muller():
 
 def test_sample_mcmc():
     """Test the MCMC sampler."""
-    np.random.seed(0)
+    rng = np.random.default_rng(0)
     # Define a custom log probability function (e.g., a standard normal distribution)
     def log_prob_func(x):
         return -0.5 * x**2
 
     n_particles = 1000
     initial_state = 0.0
-    samples = sample_mcmc(n_particles, log_prob_func, initial_state)
+    samples = sample_mcmc(
+        n_particles, log_prob_func, initial_state, rng, burn_in=500
+    )
     # Check the moments of the sampled distribution
     assert np.isclose(np.mean(samples), 0, atol=0.1)
     assert np.isclose(np.var(samples), 1, atol=0.1)


### PR DESCRIPTION
Adds two new methods to the generator module for sampling particle distributions:
- `sample_box_muller`: Samples from a Maxwellian distribution using the Box-Muller transform.
- `sample_mcmc`: Samples from a custom distribution using the Metropolis-Hastings MCMC algorithm. Also adds corresponding tests for both methods.