### PR TITLE
feat: Add multi-dimensional support to sampling methods

### DIFF
--- a/src/vdfpy/generator/generator.py
+++ b/src/vdfpy/generator/generator.py
@@ -2,6 +2,7 @@
 
 import random
 import math
+from typing import Union
 import numpy as np
 import pandas as pd
 
@@ -137,13 +138,19 @@ def make_clusters(
 
 
 def sample_box_muller(
-    n_particles: int, bulk_velocity: float, temperature: float, *, rng: np.random.Generator = None
+    n_particles: int,
+    bulk_velocity: float,
+    temperature: float,
+    *,
+    n_dims: int = 1,
+    rng: np.random.Generator = None,
 ) -> np.ndarray:
     """Sample particles from a Maxwellian distribution using the Box-Muller method.
     Args:
         n_particles (int): Number of particles to sample.
         bulk_velocity (float): Bulk velocity of the distribution.
         temperature (float): Temperature of the distribution.
+        n_dims (int, optional): The number of dimensions. Defaults to 1.
         rng (np.random.Generator, optional): Random number generator instance. Defaults to None.
     Returns:
         np.ndarray: Array of particle velocities.
@@ -151,9 +158,10 @@ def sample_box_muller(
     if rng is None:
         rng = np.random.default_rng()
 
-    # We need n_particles samples, Box-Muller generates pairs of samples.
-    # So we generate ceil(n_particles / 2) pairs.
-    num_pairs = (n_particles + 1) // 2
+    # We need n_particles * n_dims samples, Box-Muller generates pairs of samples.
+    # So we generate ceil(n_particles * n_dims / 2) pairs.
+    num_samples = n_particles * n_dims
+    num_pairs = (num_samples + 1) // 2
     u1 = rng.random(num_pairs)
     u2 = rng.random(num_pairs)
 
@@ -164,7 +172,11 @@ def sample_box_muller(
     y = r * np.sin(theta)
 
     # Combine and truncate to get n_particles samples
-    z = np.concatenate((x, y))[:n_particles]
+    z = np.concatenate((x, y))[:num_samples]
+
+    # Reshape to (n_particles, n_dims)
+    if n_dims > 1:
+        z = z.reshape(n_particles, n_dims)
 
     # Scale and shift to match the given moments
     sigma = np.sqrt(temperature)
@@ -175,8 +187,9 @@ def sample_box_muller(
 def sample_mcmc(
     n_particles: int,
     log_prob_func: callable,
-    initial_state: float,
+    initial_state: Union[float, np.ndarray],
     rng: np.random.Generator,
+    n_dims: int = 1,
     proposal_width: float = 1.0,
     burn_in: int = 100,
 ) -> np.ndarray:
@@ -184,8 +197,9 @@ def sample_mcmc(
     Args:
         n_particles (int): Number of particles to sample.
         log_prob_func (callable): Function that computes the log probability of the distribution.
-        initial_state (float): Initial state for the MCMC sampler.
+        initial_state (Union[float, np.ndarray]): Initial state for the MCMC sampler.
         rng (np.random.Generator): Random number generator.
+        n_dims (int, optional): The number of dimensions. Defaults to 1.
         proposal_width (float, optional): Width of the proposal distribution. Defaults to 1.0.
         burn_in (int, optional): Number of burn-in samples to discard. Defaults to 100.
     Returns:
@@ -193,14 +207,20 @@ def sample_mcmc(
     """
     # Initialize the MCMC chain
     total_samples = n_particles + burn_in
-    chain = np.zeros(total_samples)
+    if n_dims > 1:
+        chain = np.zeros((total_samples, n_dims))
+    else:
+        chain = np.zeros(total_samples)
     chain[0] = initial_state
     log_prob_current = log_prob_func(initial_state)
 
     # Run the MCMC sampler
     for i in range(1, total_samples):
         # Propose a new state
-        proposal = chain[i - 1] + rng.normal(0, proposal_width)
+        if n_dims > 1:
+            proposal = chain[i - 1] + rng.normal(0, proposal_width, size=n_dims)
+        else:
+            proposal = chain[i - 1] + rng.normal(0, proposal_width)
         # Compute the acceptance ratio
         log_prob_proposal = log_prob_func(proposal)
         log_acceptance_ratio = log_prob_proposal - log_prob_current

--- a/src/vdfpy/generator/generator.py
+++ b/src/vdfpy/generator/generator.py
@@ -207,20 +207,16 @@ def sample_mcmc(
     """
     # Initialize the MCMC chain
     total_samples = n_particles + burn_in
-    if n_dims > 1:
-        chain = np.zeros((total_samples, n_dims))
-    else:
-        chain = np.zeros(total_samples)
+    shape = (total_samples, n_dims) if n_dims > 1 else (total_samples,)
+    chain = np.zeros(shape)
     chain[0] = initial_state
     log_prob_current = log_prob_func(initial_state)
 
     # Run the MCMC sampler
     for i in range(1, total_samples):
         # Propose a new state
-        if n_dims > 1:
-            proposal = chain[i - 1] + rng.normal(0, proposal_width, size=n_dims)
-        else:
-            proposal = chain[i - 1] + rng.normal(0, proposal_width)
+        noise_size = n_dims if n_dims > 1 else None
+        proposal = chain[i - 1] + rng.normal(0, proposal_width, size=noise_size)
         # Compute the acceptance ratio
         log_prob_proposal = log_prob_func(proposal)
         log_acceptance_ratio = log_prob_proposal - log_prob_current

--- a/tests/generator/test_generator.py
+++ b/tests/generator/test_generator.py
@@ -16,6 +16,21 @@ def test_sample_box_muller():
     assert np.isclose(np.var(velocities), temperature, atol=0.1)
 
 
+def test_sample_box_muller_3d():
+    """Test the Box-Muller sampler in 3D."""
+    rng = np.random.default_rng(0)
+    n_particles = 10000
+    bulk_velocity = 1.0
+    temperature = 2.0
+    n_dims = 3
+    velocities = sample_box_muller(
+        n_particles, bulk_velocity, temperature, n_dims=n_dims, rng=rng
+    )
+    # Check the moments of the sampled distribution
+    assert np.all(np.isclose(np.mean(velocities, axis=0), bulk_velocity, atol=0.1))
+    assert np.all(np.isclose(np.var(velocities, axis=0), temperature, atol=0.1))
+
+
 def test_sample_mcmc():
     """Test the MCMC sampler."""
     rng = np.random.default_rng(0)
@@ -31,3 +46,27 @@ def test_sample_mcmc():
     # Check the moments of the sampled distribution
     assert np.isclose(np.mean(samples), 0, atol=0.1)
     assert np.isclose(np.var(samples), 1, atol=0.1)
+
+
+def test_sample_mcmc_3d():
+    """Test the MCMC sampler in 3D."""
+    rng = np.random.default_rng(0)
+    # Define a custom log probability function (e.g., a standard normal distribution)
+    def log_prob_func(x):
+        return -0.5 * np.sum(x**2)
+
+    n_particles = 5000
+    n_dims = 3
+    initial_state = np.zeros(n_dims)
+    samples = sample_mcmc(
+        n_particles,
+        log_prob_func,
+        initial_state,
+        rng,
+        n_dims=n_dims,
+        proposal_width=0.5,
+        burn_in=2000,
+    )
+    # Check the moments of the sampled distribution
+    assert np.all(np.isclose(np.mean(samples, axis=0), 0, atol=0.1))
+    assert np.all(np.isclose(np.var(samples, axis=0), 1, atol=0.2))


### PR DESCRIPTION
This commit extends the `sample_box_muller` and `sample_mcmc` functions in `generator.py` to support multi-dimensional sampling.

- A new `n_dims` parameter has been added to both functions to specify the desired number of dimensions.
- The core logic of both samplers has been updated to generate and handle multi-dimensional data.
- New unit tests have been added to verify the correctness of the multi-dimensional output for both samplers.