### PR TITLE
Add sampling methods section to generator notebook

### DIFF
--- a/docs/generator.ipynb
+++ b/docs/generator.ipynb
@@ -270,7 +270,7 @@
     "def custom_log_prob(x):\n",
     "    # A simple mixture of two Gaussians as a custom distribution\n",
     "    # p(x) ~ 0.3 * N(-2, 1) + 0.7 * N(2, 1)\n",
-    "    return np.log(0.3 * np.exp(-0.5 * (x + 2)**2) + 0.7 * np.exp(-0.5 * (x - 2)**2))\n",
+    "    return np.logaddexp(np.log(0.3) - 0.5 * (x + 2)**2, np.log(0.7) - 0.5 * (x - 2)**2)\n",
     "\n",
     "n_particles = 10000\n",
     "initial_state = 0.0\n",

--- a/docs/generator.ipynb
+++ b/docs/generator.ipynb
@@ -200,6 +200,98 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7d2c270b",
+   "metadata": {},
+   "source": [
+    "## Sampling Methods\n",
+    "\n",
+    "We also provide methods for sampling from distributions directly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d70759ad",
+   "metadata": {},
+   "source": [
+    "### Box-Muller Method\n",
+    "\n",
+    "The Box-Muller transform is a random number sampling method for generating pairs of independent, standard, normally distributed (zero expectation, unit variance) random numbers, given a source of uniformly distributed random numbers. We provide a function `sample_box_muller` to sample from Maxwellian distributions. This function supports 1D, 2D, and 3D sampling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7614a4d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vdfpy.generator import sample_box_muller\n",
+    "\n",
+    "n_particles = 10000\n",
+    "bulk_velocity = 0.0\n",
+    "temperature = 1.0\n",
+    "\n",
+    "# 1D example\n",
+    "samples_bm = sample_box_muller(n_particles, bulk_velocity, temperature, rng=rng)\n",
+    "\n",
+    "df_bm = pd.DataFrame(samples_bm, columns=[\"x\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb1a2074",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp = sns.histplot(df_bm, x=\"x\", stat=\"density\", kde=True)\n",
+    "hp.set(title=\"Box-Muller Sampling (Maxwellian)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be162ef5",
+   "metadata": {},
+   "source": [
+    "### Markov Chain Monte Carlo (MCMC) Method\n",
+    "\n",
+    "Markov Chain Monte Carlo (MCMC) methods comprise a class of algorithms for sampling from a probability distribution. By constructing a Markov chain that has the desired distribution as its equilibrium distribution, one can obtain a sample of the desired distribution by observing the chain after a number of steps. We provide `sample_mcmc` for sampling from a customized distribution. This function also supports 1D, 2D, and 3D sampling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "804f2c6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vdfpy.generator import sample_mcmc\n",
+    "\n",
+    "def custom_log_prob(x):\n",
+    "    # A simple mixture of two Gaussians as a custom distribution\n",
+    "    # p(x) ~ 0.3 * N(-2, 1) + 0.7 * N(2, 1)\n",
+    "    return np.log(0.3 * np.exp(-0.5 * (x + 2)**2) + 0.7 * np.exp(-0.5 * (x - 2)**2))\n",
+    "\n",
+    "n_particles = 10000\n",
+    "initial_state = 0.0\n",
+    "samples_mcmc = sample_mcmc(n_particles, custom_log_prob, initial_state, rng=rng, burn_in=500)\n",
+    "\n",
+    "df_mcmc = pd.DataFrame(samples_mcmc, columns=[\"x\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a17f7344",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp = sns.histplot(df_mcmc, x=\"x\", stat=\"density\", kde=True)\n",
+    "hp.set(title=\"MCMC Sampling (Custom Distribution)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Generating Pseudo-Data from VDFpy\n",


### PR DESCRIPTION
Added a new section 'Sampling Methods' to docs/generator.ipynb. This section includes subsections for 'Box-Muller Method' and 'Markov Chain Monte Carlo (MCMC) Method', demonstrating how to use `sample_box_muller` and `sample_mcmc` from `vdfpy.generator`. Included code examples for 1D sampling and mentioned support for 2D and 3D.