### PR TITLE
Fix pyspedas imports and bump dependency version

### DIFF
--- a/docs/mms-fpi.ipynb
+++ b/docs/mms-fpi.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pytplot import time_double, time_string\n",
+    "from pyspedas import time_double, time_string\n",
     "\n",
     "time = \"2017-09-10/09:32:20\"\n",
     "window = 4.\n",
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyspedas.mms.particles.mms_part_slice2d import mms_part_slice2d\n",
+    "from pyspedas.projects.mms import mms_part_slice2d\n",
     "\n",
     "mms_part_slice2d(\n",
     "    time=time,\n",
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyspedas.particles.spd_slice2d.slice1d_plot import plot\n",
+    "from pyspedas import slice1d_plot as plot\n",
     "\n",
     "plot(the_slice, 'x', [-100, 100])  # summed from Vv=[-100, 100]"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "scikit-learn>=1.5.2",
     "scipy>=1.14.1",
     "pandas>=2.2.3",
-    "pyspedas>=1.7.1",
+    "pyspedas>=2.0.0",
     "umap-learn>=0.5.7",
     "yt>=4.3.0,<5",
 ]


### PR DESCRIPTION
- Update `docs/mms-fpi.ipynb` to use `pyspedas` v2.0+ API.
- Replace `pytplot` imports with `pyspedas` imports.
- Update `mms_part_slice2d` and `slice1d_plot` imports to their canonical locations.
- Bump `pyspedas` dependency to `>=2.0.0` in `pyproject.toml`.